### PR TITLE
fix: update crystal version to avoid dependency issue

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - Brian J. Cardiff <bcardiff@manas.tech>
 
-crystal: '>= 0.34.0'
+crystal: '1.0.0'
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - Brian J. Cardiff <bcardiff@manas.tech>
 
-crystal: 1.0.0
+crystal: '>= 0.34.0'
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - Brian J. Cardiff <bcardiff@manas.tech>
 
-crystal: 0.34.0
+crystal: 1.0.0
 
 license: MIT


### PR DESCRIPTION
Fixes failed dependency issue:
```
14:57 $ shards update
Resolving dependencies
Fetching https://github.com/amberframework/amber-router.git
Fetching https://github.com/crystal-lang/json_mapping.cr.git
Fetching https://github.com/crystal-ameba/ameba.git
Unable to satisfy the following requirements:

- `crystal (>= 0.35.0)` required by `amber_router 0.4.4`
- `crystal (~> 0.34, >= 0.34.0)` required by `json_mapping 0.1.0`
- `crystal (>= 0.35.0)` required by `ameba 0.14.2`
Failed to resolve dependencies, try updating incompatible shards or use --ignore-crystal-version as a workaround if no update is available.
```